### PR TITLE
Add LIBS input property to GENERATE_ARDUINO_EXAMPLE

### DIFF
--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -179,6 +179,7 @@
 #                          LIBRARY library_name
 #                          EXAMPLE example_name
 #                          [BOARD  board_id]
+#                          [LIBS  lib1 lib2 ... libN]
 #                          [PORT port]
 #                          [SERIAL serial command]
 #                          [PORGRAMMER programmer_id]
@@ -189,6 +190,7 @@
 #        LIBRARY      - Library name                           [REQUIRED]
 #        EXAMPLE      - Example name                           [REQUIRED]
 #        BOARD        - Board ID
+#        LIBS         - Libraries to link
 #        PORT         - Serial port [optional]
 #        SERIAL       - Serial command [optional]
 #        PROGRAMMER   - Programmer id (enables programmer support)
@@ -585,7 +587,7 @@ function(GENERATE_ARDUINO_EXAMPLE INPUT_NAME)
     parse_generator_arguments(${INPUT_NAME} INPUT
                               ""                                       # Options
                               "LIBRARY;EXAMPLE;BOARD;PORT;PROGRAMMER"  # One Value Keywords
-                              "SERIAL;AFLAGS"                          # Multi Value Keywords
+                              "SERIAL;AFLAGS;LIBS"                     # Multi Value Keywords
                               ${ARGN})
 
 


### PR DESCRIPTION
Some arduino examples with multiple dependencies give
linking errors when build with the generate_arduino_example command

This change add the LIBS input property. This works like the existing
LIBS inputs on generate_arduino_firmware and generate_arduino_library

The cmake source code for the generate_arduino_example already handled
this input, so no changes were necessary for the function itself.